### PR TITLE
Container override from the CLI

### DIFF
--- a/janis_assistant/cli.py
+++ b/janis_assistant/cli.py
@@ -259,6 +259,12 @@ def add_translate_args(parser):
         "Including this flag will disable this check, and empty containers can be used.",
     )
 
+    parser.add_argument(
+        "--container-override",
+        help="Override a tool's container by specifying a new container. This argument should be specified in the "
+        "following (comma separated) format: t1=v1,t2=v2. Eg toolid=container/override:version,toolid2=<container>.",
+    )
+
 
 def add_inputs_args(parser):
     from janis_core import HINTS, HintEnum
@@ -392,6 +398,12 @@ def add_run_args(parser):
         action="store_true",
         help="Some tools you use may not include a container, this would usually (and intentionally) cause an error. "
         "Including this flag will disable this check, and empty containers can be used.",
+    )
+
+    parser.add_argument(
+        "--container-override",
+        help="Override a tool's container by specifying a new container. This argument should be specified in the "
+        "following (comma separated) format: t1=v1,t2=v2. Eg toolid=container/override:version,toolid2=<container>.",
     )
 
     parser.add_argument(
@@ -756,6 +768,7 @@ def do_run(args):
         no_store=args.no_store,
         allow_empty_container=args.allow_empty_container,
         check_files=not args.skip_file_check,
+        container_override=parse_container_override_format(args.container_override),
     )
 
     Logger.info("Exiting")
@@ -857,7 +870,27 @@ def do_rawquery(args):
     return print(tabulate.tabulate(result))
 
 
+def parse_container_override_format(container_override):
+    if not container_override:
+        return None
+
+    co = {}
+
+    for s in container_override.split(","):
+        split = s.split("=")
+        if len(split) != 2:
+            raise Exception(
+                f"The container-override parameter '{s}' is NOT in the correct format, expected k=v"
+            )
+        co[split[0]] = split[1]
+
+    return co
+
+
 def do_translate(args):
+
+    container_override = parse_container_override_format(args.container_override)
+
     translate(
         tool=args.workflow,
         translation=args.translation,
@@ -865,6 +898,7 @@ def do_translate(args):
         output_dir=args.output_dir,
         force=args.no_cache,
         allow_empty_container=args.allow_empty_container,
+        container_override=container_override,
     )
 
 

--- a/janis_assistant/cli.py
+++ b/janis_assistant/cli.py
@@ -874,6 +874,9 @@ def parse_container_override_format(container_override):
     if not container_override:
         return None
 
+    if "," not in container_override and "=" not in container_override:
+        return {"*": container_override}
+
     co = {}
 
     for s in container_override.split(","):

--- a/janis_assistant/main.py
+++ b/janis_assistant/main.py
@@ -112,6 +112,7 @@ def translate(
     output_dir: Optional[str] = None,
     inputs: Union[str, dict] = None,
     allow_empty_container=False,
+    container_override=None,
     **kwargs,
 ):
 
@@ -134,6 +135,7 @@ def translate(
             hints=hints,
             additional_inputs=inputsdict,
             allow_empty_container=allow_empty_container,
+            container_override=container_override,
         )
     elif isinstance(toolref, (j.CommandTool, j.CodeTool)):
         wfstr = toolref.translate(
@@ -142,6 +144,7 @@ def translate(
             to_disk=bool(output_dir),
             export_path=output_dir or "./{language}",
             allow_empty_container=allow_empty_container,
+            container_override=container_override,
         )
 
     else:
@@ -380,6 +383,7 @@ def fromjanis(
     no_store=False,
     allow_empty_container=False,
     check_files=True,
+    container_override: dict = None,
     **kwargs,
 ):
     cm = ConfigManager.manager()
@@ -468,6 +472,7 @@ def fromjanis(
             run_in_background=should_run_in_background,
             mysql=mysql,
             allow_empty_container=allow_empty_container,
+            container_override=container_override,
             check_files=check_files,
         )
         Logger.log("Finished starting task task")

--- a/janis_assistant/management/configmanager.py
+++ b/janis_assistant/management/configmanager.py
@@ -180,6 +180,7 @@ class ConfigManager:
         run_in_background=True,
         mysql=False,
         allow_empty_container=False,
+        container_override: dict = None,
         check_files=True,
     ) -> WorkflowManager:
 
@@ -200,6 +201,7 @@ class ConfigManager:
             run_in_background=run_in_background,
             mysql=mysql,
             allow_empty_container=allow_empty_container,
+            container_override=container_override,
             check_files=check_files,
         )
 

--- a/janis_assistant/management/workflowmanager.py
+++ b/janis_assistant/management/workflowmanager.py
@@ -140,6 +140,7 @@ class WorkflowManager:
         run_in_background=True,
         mysql=False,
         allow_empty_container=False,
+        container_override: dict = None,
         check_files=True,
     ):
 
@@ -181,6 +182,7 @@ class WorkflowManager:
             max_cores=max_cores or jc.environment.max_cores,
             max_memory=max_memory or jc.environment.max_ram,
             allow_empty_container=allow_empty_container,
+            container_override=container_override,
             check_files=check_files,
         )
 
@@ -596,6 +598,7 @@ class WorkflowManager:
         max_cores=None,
         max_memory=None,
         allow_empty_container=False,
+        container_override: dict = None,
         check_files=True,
     ):
         if self.database.progressDB.has(ProgressKeys.saveWorkflow):
@@ -615,6 +618,7 @@ class WorkflowManager:
             write_inputs_file=False,
             export_path=os.path.join(outdir_workflow, "original"),
             allow_empty_container=allow_empty_container,
+            container_override=container_override,
         )
 
         Logger.info(f"Saved workflow with id '{workflow.id()}' to '{outdir_workflow}'")
@@ -647,6 +651,7 @@ class WorkflowManager:
             max_cores=max_cores,
             max_mem=max_memory,
             allow_empty_container=allow_empty_container,
+            container_override=container_override,
         )
 
         self.evaluate_output_params(


### PR DESCRIPTION
As introduced in https://github.com/PMCC-BioinformaticsCore/janis-core/pull/15, a user might want the ability to override a container at runtime (especially when no container is specified).

This ability is important to ensure that a tool can be contributed to the toolbox without requiring a container (which could be for legal reasons).

You can specify a container override for `run` and `translate` CLI methods. It has the structure: `toolid=containervalue`. This field is comma-separated, so multiple container overrides can be specified.

```
--container-override "tool1=container/override
```

> A wildcard can be specified with the `*` symbol: `'*=newcontainer:tag` or simply providing a single container with no toolid (`--container-override newcontainer:tag`).
