### PR TITLE
Cromwell DB Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,15 +219,20 @@ Extra Cromwell comments:
 
 ### Databases
 
-Cromwell requires a database to use some features: call-caching, resumability for cluster failures and so on.
+> This feature requires better documentation in the primary Janis documentation.
 
-There are two ways to do this:
+Some features of Cromwell require a database to use: call-caching, resumability for cluster failures and so on.
 
-- Run a mysql instance,
-    - Have Janis run you a mysql instance 
-- Use the [file-based database](https://cromwell.readthedocs.io/en/stable/Configuring/#using-cromwell-with-postgresql) for Cromwell.
+Previously, this has been managed through automatically spinning up a mysql instance with Docker / Singularity, however this has been unstable. Now, as Cromwell supports a [file-based database](https://cromwell.readthedocs.io/en/stable/Configuring/#database), this is now the default.
 
-This functionality has been optional in the past, but it's now REQUIRED.
+- No options -> file-based DB
+- `--no-database` -> No database is ran
+- `--mysql` -> Automatically provision and manage a mysql server (unchanged)
+- Configure an existing 
+
+Call caching has been enabled by default using the `file` based method, we strongly recommend downloading Cromwell >50 and using `fingerprint`, see [call caching documentation](https://janis.readthedocs.io/en/latest/references/callcaching.html) for more information.
+
+WARNING: `fingerprint` will become the default once Cromwell 50 has been released. This might break if you're using older versions of Cromwell.
 
 
 ### Filesystem

--- a/README.md
+++ b/README.md
@@ -217,6 +217,19 @@ Extra Cromwell comments:
 - If asking Janis to start its own Cromwell instance, it requires the jar to be exported as `$cromwelljar`.
 
 
+### Databases
+
+Cromwell requires a database to use some features: call-caching, resumability for cluster failures and so on.
+
+There are two ways to do this:
+
+- Run a mysql instance,
+    - Have Janis run you a mysql instance 
+- Use the [file-based database](https://cromwell.readthedocs.io/en/stable/Configuring/#using-cromwell-with-postgresql) for Cromwell.
+
+This functionality has been optional in the past, but it's now REQUIRED.
+
+
 ### Filesystem
 
 There is a weak concept of a filesystem for where your workflow is executed. This tool is really only developed

--- a/janis_assistant/cli.py
+++ b/janis_assistant/cli.py
@@ -203,6 +203,12 @@ def add_spider_args(parser):
 
 def add_resume_args(parser):
     parser.add_argument("wid", help="WID to resume")
+    parser.add_argument(
+        "--foreground",
+        action="store_true",
+        help="By default, the workflow will be resubmitted per your template's recommendation. "
+        "(This is often in the background). Use this option to force running in the foreground.",
+    )
     return parser
 
 

--- a/janis_assistant/data/enums/workflowmetadatakeys.py
+++ b/janis_assistant/data/enums/workflowmetadatakeys.py
@@ -32,4 +32,4 @@ class WorkflowMetadataDbKeys(Enum):
     submission_workflow = "submission_workflow"
     submission_inputs = "submission_inputs"
     submission_resources = "submission_resources"
-    should_manage_database = "should_manage_database"
+    dbconfig = "dbconfig"

--- a/janis_assistant/data/providers/workflowmetadataprovider.py
+++ b/janis_assistant/data/providers/workflowmetadataprovider.py
@@ -50,7 +50,7 @@ class WorkflowMetadataDbProvider(KvDB):
             self.error = None
 
             self.configuration = None
-            self.should_manage_database = True
+            self.dbconfig = None
 
             self.author = lookup_username()
 

--- a/janis_assistant/engines/cromwell/cromwellconfiguration.py
+++ b/janis_assistant/engines/cromwell/cromwellconfiguration.py
@@ -166,12 +166,21 @@ class CromwellConfiguration(Serializable):
 
     class Database(Serializable):
         class Db(Serializable):
-            def __init__(self, driver, url, user, password, connection_timeout):
+            def __init__(
+                self,
+                driver,
+                url,
+                connection_timeout,
+                user=None,
+                password=None,
+                num_threads=None,
+            ):
                 self.driver = driver
                 self.url = url
                 self.user = user
                 self.password = password
                 self.connectionTimeout = connection_timeout
+                self.num_threads = num_threads
 
         def __init__(self, profile=None, insert_batch_size=None, db: Db = None):
             self.db = db
@@ -199,6 +208,27 @@ class CromwellConfiguration(Serializable):
                     user=username,
                     password=password,
                     connection_timeout=connection_timeout,
+                ),
+            )
+
+        @classmethod
+        def filebased_db(cls, location, connection_timeout=120000, num_threads=1):
+            return cls(
+                profile="slick.jdbc.HsqldbProfile$",
+                db=cls.Db(
+                    driver="org.hsqldb.jdbcDriver",
+                    url=f"""\
+jdbc:hsqldb:file:{location};
+shutdown=false;
+hsqldb.default_table_type=cached;hsqldb.tx=mvcc;
+hsqldb.result_max_memory_rows=10000;
+hsqldb.large_data=true;
+hsqldb.applog=1;
+hsqldb.lob_compressed=true;
+hsqldb.script_format=3
+""",
+                    connection_timeout=connection_timeout,
+                    num_threads=num_threads,
                 ),
             )
 

--- a/janis_assistant/engines/cromwell/main.py
+++ b/janis_assistant/engines/cromwell/main.py
@@ -389,7 +389,7 @@ class Cromwell(Engine):
         if cromwelljar:
             potentials.append(os.path.expanduser(cromwelljar))
         if man.cromwell.jarpath:
-            potentials.append(os.path.expanduser(cromwelljar))
+            potentials.append(os.path.expanduser(man.cromwell.jarpath))
         if fromenv:
             potentials.append(fromenv)
         potentials.extend(

--- a/janis_assistant/main.py
+++ b/janis_assistant/main.py
@@ -516,11 +516,18 @@ def get_filescheme_from_fs(fs, **kwargs):
     raise Exception(f"Couldn't initialise filescheme with unrecognised type: '{fs}'")
 
 
-def resume(wid):
+def resume(wid, foreground: bool = False):
     wm = ConfigManager.manager().from_wid(wid, readonly=False)
     if not wm:
         raise Exception("Couldn't find workflow manager with wid = " + str(wid))
-    wm.resume()
+
+    run_in_background = False
+    if foreground:
+        run_in_background = False
+    elif wm.database.workflowmetadata.configuration.run_in_background:
+        run_in_background = True
+
+    wm.start_or_submit(run_in_background=run_in_background)
 
 
 def pause(wid):

--- a/janis_assistant/main.py
+++ b/janis_assistant/main.py
@@ -16,7 +16,7 @@ from typing import Optional, Dict, Union, Type, List
 from janis_core import InputQualityType
 
 from janis_assistant.data.providers.janisdbprovider import TaskRow
-from janis_assistant.templates import TemplateInput
+from janis_assistant.templates import TemplateInput, EnvironmentTemplate
 
 from janis_assistant.management.workflowmanager import WorkflowManager
 
@@ -373,7 +373,7 @@ def fromjanis(
     recipes=None,
     run_in_background=True,
     run_in_foreground=None,
-    mysql=False,
+    dbconfig=None,
     only_toolbox=False,
     no_store=False,
     allow_empty_container=False,
@@ -464,7 +464,7 @@ def fromjanis(
             max_memory=max_memory,
             keep_intermediate_files=keep_intermediate_files,
             run_in_background=should_run_in_background,
-            mysql=mysql,
+            dbconfig=dbconfig,
             allow_empty_container=allow_empty_container,
             check_files=check_files,
         )
@@ -481,7 +481,7 @@ def fromjanis(
         raise e
 
 
-def get_engine_from_eng(eng, wid, logfile, confdir, execdir: str, watch=True, **kwargs):
+def get_engine_from_eng(eng, wid, logfile, confdir, execdir: str, **kwargs):
 
     if eng == "cromwell":
         url = kwargs.get("cromwell_url") or JanisConfiguration.manager().cromwell.url

--- a/janis_assistant/management/configmanager.py
+++ b/janis_assistant/management/configmanager.py
@@ -178,7 +178,7 @@ class ConfigManager:
         max_memory=None,
         keep_intermediate_files=False,
         run_in_background=True,
-        mysql=False,
+        dbconfig=None,
         allow_empty_container=False,
         check_files=True,
     ) -> WorkflowManager:
@@ -198,7 +198,7 @@ class ConfigManager:
             max_memory=max_memory,
             keep_intermediate_files=keep_intermediate_files,
             run_in_background=run_in_background,
-            mysql=mysql,
+            dbconfig=dbconfig,
             allow_empty_container=allow_empty_container,
             check_files=check_files,
         )

--- a/janis_assistant/management/configuration.py
+++ b/janis_assistant/management/configuration.py
@@ -484,15 +484,6 @@ class JanisConfiguration(NoAttributeErrors):
 
 
 class JanisDatabaseConfigurationHelper:
-    """
-    Heirarchy:
-
-    - provided mysql_url
-    - skip database
-    - managed_mysql_instance
-    -
-    """
-
     class DatabaseTypeToUse(Enum):
         none = "none"
         existing = "existing"

--- a/janis_assistant/management/configuration.py
+++ b/janis_assistant/management/configuration.py
@@ -1,4 +1,5 @@
 import os.path
+from enum import Enum
 from typing import Optional, List, Union
 import ruamel.yaml
 
@@ -120,6 +121,12 @@ class JanisConfiguration(NoAttributeErrors):
             Url = "url"
             Memory = "memory_mb"
             CallCachingMethod = "call_caching_method"
+            MySqlURL = "mysql_url"
+            MySqlUsername = "mysql_username"
+            MySqlPassword = "mysql_password"
+            MySqlDbName = "mysql_dbname"
+            UseManagedMySqlInstance = "should_manage_mysql"
+            UseDatabase = "use_database"
 
         def __init__(self, d: dict, default: dict):
             d = d if d else {}
@@ -138,6 +145,42 @@ class JanisConfiguration(NoAttributeErrors):
 
             self.call_caching_method = JanisConfiguration.get_value_for_key(
                 d, self.Keys.CallCachingMethod, default
+            )
+
+            self.mysql_url = JanisConfiguration.get_value_for_key(
+                d, self.Keys.MySqlURL, default
+            )
+            self.mysql_username = JanisConfiguration.get_value_for_key(
+                d, self.Keys.MySqlUsername, default
+            )
+            self.mysql_password = JanisConfiguration.get_value_for_key(
+                d, self.Keys.MySqlPassword, default
+            )
+            self.mysql_dbname = JanisConfiguration.get_value_for_key(
+                d, self.Keys.MySqlDbName, default
+            )
+            self.mysql_instance = JanisConfiguration.get_value_for_key(
+                d, self.Keys.UseManagedMySqlInstance, default
+            )
+
+            self.use_database = JanisConfiguration.get_value_for_key(
+                d, self.Keys.UseDatabase, default
+            )
+
+        def get_database_config_helper(self):
+            existing_config = None
+            if self.mysql_url:
+                existing_config = JanisDatabaseConfigurationHelper.MySqlInstanceConfig(
+                    url=self.mysql_url,
+                    username=self.mysql_username,
+                    password=self.mysql_password,
+                    dbname=self.mysql_dbname,
+                )
+
+            return JanisDatabaseConfigurationHelper(
+                mysql_config=existing_config,
+                skip_database=self.use_database is False,
+                run_managed_mysql_instance=self.mysql_instance,
             )
 
     class JanisConfigurationRecipes(NoAttributeErrors):
@@ -438,6 +481,97 @@ class JanisConfiguration(NoAttributeErrors):
             },
         }
         return stringify_dict_keys_or_return_value(deflt)
+
+
+class JanisDatabaseConfigurationHelper:
+    """
+    Heirarchy:
+
+    - provided mysql_url
+    - skip database
+    - managed_mysql_instance
+    -
+    """
+
+    class DatabaseTypeToUse(Enum):
+        none = "none"
+        existing = "existing"
+        managed = "managed"
+        filebased = "filebased"
+
+    class MySqlInstanceConfig:
+        def __init__(self, url, username, password, dbname="cromwell"):
+            self.url = url
+            self.username = username
+            self.password = password
+            self.dbname = dbname
+
+    def __init__(
+        self,
+        mysql_config: MySqlInstanceConfig = None,
+        run_managed_mysql_instance=None,
+        skip_database=None,
+    ):
+        self.mysql_config = mysql_config
+        self.should_manage_mysql = run_managed_mysql_instance
+        self.skip_database = skip_database
+
+    def which_db_to_use(self) -> DatabaseTypeToUse:
+        if self.mysql_config is not None:
+            return self.DatabaseTypeToUse.existing
+        elif self.skip_database:
+            return self.DatabaseTypeToUse.none
+        elif self.should_manage_mysql is True:
+            return self.DatabaseTypeToUse.managed
+        return self.DatabaseTypeToUse.filebased
+
+    def get_config_for_existing_config(self):
+        t = self.which_db_to_use()
+        if t != self.DatabaseTypeToUse.existing:
+            raise Exception(
+                f"Attempted to request database config for {self.DatabaseTypeToUse.existing.value} config, "
+                f"but the database helper wants to use {t.value}"
+            )
+        from janis_assistant.engines.cromwell.cromwellconfiguration import (
+            CromwellConfiguration,
+        )
+
+        config = self.mysql_config
+        return CromwellConfiguration.Database.mysql(
+            url=config.url,
+            username=config.username,
+            password=config.password,
+            database=config.dbname,
+        )
+
+    def get_config_for_filebased_db(self, path):
+        t = self.which_db_to_use()
+        if t != self.DatabaseTypeToUse.filebased:
+            raise Exception(
+                f"Attempted to request database config for {self.DatabaseTypeToUse.filebased.value} config, "
+                f"but the database helper wants to use {t.value}"
+            )
+        from janis_assistant.engines.cromwell.cromwellconfiguration import (
+            CromwellConfiguration,
+        )
+
+        return CromwellConfiguration.Database.filebased_db(location=path)
+
+    def get_config_for_managed_mysql(self, url):
+        t = self.which_db_to_use()
+        if t != self.DatabaseTypeToUse.managed:
+            raise Exception(
+                f"Attempted to request database config for {self.DatabaseTypeToUse.managed.value} "
+                f"config, but the database helper wants to use {t.value}"
+            )
+
+        from janis_assistant.engines.cromwell.cromwellconfiguration import (
+            CromwellConfiguration,
+        )
+
+        return CromwellConfiguration.Database.mysql(
+            username=None, password=None, url=url
+        )
 
 
 def stringify_dict_keys_or_return_value(d):

--- a/janis_assistant/management/workflowmanager.py
+++ b/janis_assistant/management/workflowmanager.py
@@ -205,7 +205,8 @@ class WorkflowManager:
 
         if not dryrun:
             if (
-                jc.template
+                not run_in_background
+                and jc.template
                 and jc.template.template
                 and jc.template.template.can_run_in_foreground is False
             ):

--- a/janis_assistant/management/workflowmanager.py
+++ b/janis_assistant/management/workflowmanager.py
@@ -40,7 +40,10 @@ from janis_assistant.engines import (
     Engine,
 )
 from janis_assistant.environments.environment import Environment
-from janis_assistant.management.configuration import JanisConfiguration
+from janis_assistant.management.configuration import (
+    JanisConfiguration,
+    JanisDatabaseConfigurationHelper,
+)
 from janis_assistant.management.filescheme import FileScheme, LocalFileScheme
 from janis_assistant.management.mysql import MySql
 from janis_assistant.management.notificationmanager import NotificationManager
@@ -138,7 +141,7 @@ class WorkflowManager:
         max_memory=None,
         keep_intermediate_files=False,
         run_in_background=True,
-        mysql=False,
+        dbconfig=None,
         allow_empty_container=False,
         check_files=True,
     ):
@@ -162,7 +165,7 @@ class WorkflowManager:
         tm.database.workflowmetadata.executiondir = None
         tm.database.workflowmetadata.keepexecutiondir = keep_intermediate_files
         tm.database.workflowmetadata.configuration = jc
-        tm.database.workflowmetadata.should_manage_database = mysql
+        tm.database.workflowmetadata.dbconfig = dbconfig
 
         # This is the only time we're allowed to skip the tm.set_status
         # This is a temporary stop gap until "notification on status" is implemented.
@@ -325,7 +328,7 @@ class WorkflowManager:
         #     )
         #     Logger.warn(txt)
 
-        if bl:
+        if bl is not None:
             self.poll_stored_metadata_with_blessed(bl)
         else:
             self.poll_stored_metadata_with_clear()
@@ -520,34 +523,42 @@ class WorkflowManager:
 
         is_allegedly_started = engine.test_connection()
 
-        if not is_allegedly_started:
+        if is_allegedly_started:
+            return
 
-            was_manually_started = False
+        if not isinstance(engine, Cromwell):
+            engine.start_engine()
+            return
 
-            # start mysql if it's cromwell, and then slightly change the config if one exists
-            if isinstance(engine, Cromwell):
-                if engine.config:
-                    if self.database.workflowmetadata.should_manage_database:
-                        # only here do we start mysql
-                        self.start_mysql_and_prepare_cromwell()
-                        self.database.workflowmetadata.manages_database = True
-                        was_manually_started = True
-                    else:
-                        Logger.info(
-                            "Skipping start mysql as database configuration already exists"
-                        )
+        additional_cromwell_params = []
+        if not engine.config:
+            Logger.info("Skipping start mysql as Janis is not managing the config")
+        else:
+            dbconfig: JanisDatabaseConfigurationHelper = self.database.workflowmetadata.dbconfig
+            dbtype = dbconfig.which_db_to_use()
+            if dbtype == dbconfig.DatabaseTypeToUse.existing:
+                engine.config.database = dbconfig.get_config_for_existing_config()
+            elif dbtype == dbconfig.DatabaseTypeToUse.filebased:
+                engine.config.database = dbconfig.get_config_for_filebased_db(
+                    path=self.get_path_for_component(self.WorkflowManagerPath.database)
+                    + "/cromwelldb"
+                )
+            elif dbtype == dbconfig.DatabaseTypeToUse.managed:
+                cromwelldb_config = self.start_mysql_and_prepare_cromwell_config()
+                additional_cromwell_params.append(
+                    "-Ddatabase.db.url=" + cromwelldb_config.db.url
+                )
+                engine.config.database = cromwelldb_config
+            else:
+                Logger.warn(
+                    "Skipping database config as '--no-database' option was provided."
+                )
 
-                else:
-                    Logger.info(
-                        "Skipping start mysql as Janis is not managing the config"
-                    )
-
-            if not was_manually_started:
-                engine.start_engine()
+            engine.start_engine(additional_cromwell_options=additional_cromwell_params)
             # Write the new engine details back into the database (for like PID, host and is_started)
             self.database.workflowmetadata.engine = engine
 
-    def start_mysql_and_prepare_cromwell(self):
+    def start_mysql_and_prepare_cromwell_config(self):
         scriptsdir = self.get_path_for_component(self.WorkflowManagerPath.mysql)
 
         containerdir = self.get_path_for_component(self.WorkflowManagerPath.database)
@@ -571,17 +582,10 @@ class WorkflowManager:
         )
         self.dbcontainer.start()
 
-        engine: Cromwell = self.get_engine()
-
-        engine.config.database = CromwellConfiguration.Database.mysql(username="root")
-        # engine.config.call_caching = CromwellConfiguration.CallCaching(enabled=True)
-
         port = self.dbcontainer.forwardedport
-        url = CromwellConfiguration.Database.MYSQL_URL.format(
-            url=f"127.0.0.1:{port}", database="cromwell"
+        return CromwellConfiguration.Database.mysql(
+            username="root", url=f"127.0.0.1:{port}"
         )
-        engine.start_engine(additional_cromwell_options=["-Ddatabase.db.url=" + url])
-        self.database.workflowmetadata.engine = engine
 
     def prepare_and_output_workflow_to_evaluate_if_required(
         self,


### PR DESCRIPTION
Using a managed mysql server has NOT been an effective way to manage the database. Since starting this section, Cromwell now supports a file-based DB. Although it produced significantly more data, we feel it's a crucial step to turning on call-caching.

From now, file-based DB is the default.

### CLI Options

- No database with `--no-database`
- Managed mysql with `--mysql`

### Config options

Under `cromwell`, the following options are available to you:

```yaml
cromwell:
  # Use a manged mysql instance
  mysql_url: null # URL of existing mysql
  mysql_username: null
  mysql_password: null
  mysql_dbname: "cromwell" # (default)
  # other options
  should_manage_mysql: false # true is equivalent to always specifying --mysql
  use_database: true # false is equivalent to `--no-database`
```

The intention is to turn on call_caching by default soon, when the `fingerprint` method is formally released.