### PR TITLE
Run tool directly rather than building and running subworkflow

### DIFF
--- a/janis_assistant/main.py
+++ b/janis_assistant/main.py
@@ -13,7 +13,7 @@ from textwrap import dedent
 import janis_core as j
 from typing import Optional, Dict, Union, Type, List
 
-from janis_core import InputQualityType
+from janis_core import InputQualityType, Tool
 
 from janis_assistant.data.providers.janisdbprovider import TaskRow
 from janis_assistant.templates import TemplateInput, EnvironmentTemplate
@@ -385,7 +385,7 @@ def fromjanis(
     cm = ConfigManager.manager()
     jc = JanisConfiguration.manager()
 
-    wf = resolve_tool(
+    wf: Optional[Tool] = resolve_tool(
         tool=workflow,
         name=name,
         from_toolshed=True,
@@ -395,10 +395,10 @@ def fromjanis(
     if not wf:
         raise Exception("Couldn't find workflow with name: " + str(workflow))
 
-    if isinstance(wf, j.CommandTool):
-        wf = wf.wrapped_in_wf()
-    elif isinstance(wf, j.CodeTool):
-        wf = wf.wrapped_in_wf()
+    # if isinstance(tool, j.CommandTool):
+    #     tool = tool.wrapped_in_wf()
+    # elif isinstance(tool, j.CodeTool):
+    #     tool = tool.wrapped_in_wf()
 
     # organise inputs
     inputsdict = {}
@@ -453,7 +453,7 @@ def fromjanis(
 
         tm = cm.start_task(
             wid=row.wid,
-            wf=wf,
+            tool=wf,
             environment=environment,
             validation_requirements=validation_reqs,
             batchrun_requirements=batchrun_reqs,

--- a/janis_assistant/management/configmanager.py
+++ b/janis_assistant/management/configmanager.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from shutil import rmtree
 from typing import Dict, Optional, Union
 
-from janis_core import Workflow, Logger
+from janis_core import Workflow, Logger, Tool
 
 from janis_assistant.data.models.workflow import WorkflowModel
 from janis_assistant.data.providers.janisdbprovider import TasksDbProvider, TaskRow
@@ -165,7 +165,7 @@ class ConfigManager:
     def start_task(
         self,
         wid: str,
-        wf: Workflow,
+        tool: Tool,
         task_path: str,
         environment: Environment,
         hints: Dict[str, str],
@@ -185,7 +185,7 @@ class ConfigManager:
 
         return WorkflowManager.from_janis(
             wid,
-            wf=wf,
+            tool=tool,
             outdir=task_path,
             environment=environment,
             hints=hints,

--- a/janis_assistant/modifiers/validatormodifier.py
+++ b/janis_assistant/modifiers/validatormodifier.py
@@ -81,7 +81,3 @@ class ValidatorPipelineModifier(PipelineModifierBase):
                 )
 
         return w
-
-    # def inputs_modifier(self, wf: Tool, inputs: Dict, hints: Dict[str, str]) -> Dict:
-    #     wid = wf.id()
-    #     return {wid + "_" + k: v for k, v in inputs.items()}


### PR DESCRIPTION
Directly run a tool (previously it wrapped in subworkflow). This should remove prefix required to override resources, and just generally a good cleanup. 

This requires Janis-core changes (along with other changes currently unreleased), so new version of Janis-assistant will need a new min janis-core version.