### PR TITLE
Running non-janis workflows with the assistant

### DIFF
--- a/janis_assistant/data/enums/workflowmetadatakeys.py
+++ b/janis_assistant/data/enums/workflowmetadatakeys.py
@@ -33,3 +33,5 @@ class WorkflowMetadataDbKeys(Enum):
     submission_inputs = "submission_inputs"
     submission_resources = "submission_resources"
     dbconfig = "dbconfig"
+
+    copy_partial_outputs = "copy_partial_outputs"

--- a/janis_assistant/data/providers/workflowmetadataprovider.py
+++ b/janis_assistant/data/providers/workflowmetadataprovider.py
@@ -53,6 +53,7 @@ class WorkflowMetadataDbProvider(KvDB):
             self.dbconfig = None
 
             self.author = lookup_username()
+            self.copy_partial_outputs = None
 
         self.kvdb.autocommit = True
         self.kvdb.commit()

--- a/janis_assistant/engines/cromwell/main.py
+++ b/janis_assistant/engines/cromwell/main.py
@@ -99,6 +99,9 @@ class Cromwell(Engine):
         self.connectionerrorcount = 0
         self.should_stop = False
 
+        self._timer_thread = threading.Event()
+        self.poll_metadata()
+
         if not self.connect_to_instance:
 
             # To avoid conflicts between version of Cromwell, we'll find an open
@@ -264,9 +267,6 @@ class Cromwell(Engine):
                 logfp=self._logfp,
                 # exit_function=self.something_has_happened_to_cromwell,
             )
-
-        self._timer_thread = threading.Event()
-        self.poll_metadata()
 
         return self
 

--- a/janis_assistant/engines/engine.py
+++ b/janis_assistant/engines/engine.py
@@ -2,6 +2,8 @@ import threading
 from abc import ABC, abstractmethod
 from typing import Dict, Any, Optional, List, Callable
 
+from janis_core import Logger
+
 from janis_assistant.data.models.workflow import WorkflowModel
 from janis_assistant.engines.enginetypes import EngineType
 from janis_assistant.management import Archivable
@@ -25,6 +27,7 @@ class Engine(Archivable, ABC):
     def add_callback(
         self, engine_identifier: str, callback: Callable[[WorkflowModel], None]
     ):
+        Logger.debug(f"Adding callback from engineId {engine_identifier}")
         self.progress_callbacks[engine_identifier] = self.progress_callbacks.get(
             engine_identifier, []
         ) + [callback]

--- a/janis_assistant/management/configmanager.py
+++ b/janis_assistant/management/configmanager.py
@@ -98,7 +98,7 @@ class ConfigManager:
         self.get_lazy_db_connection().remove_by_id(task.wid)
         Logger.info("Deleted task: " + task.wid)
 
-    def create_task_base(self, wf: Workflow, outdir=None, store_in_centraldb=True):
+    def create_task_base(self, name: str, outdir=None, store_in_centraldb=True):
         config = JanisConfiguration.manager()
 
         """
@@ -115,7 +115,7 @@ class ConfigManager:
         default_outdir = None
 
         if config.outputdir:
-            default_outdir = os.path.join(config.outputdir, wf.id())
+            default_outdir = os.path.join(config.outputdir, name)
 
         forbiddenids = set()
         if store_in_centraldb:
@@ -182,6 +182,7 @@ class ConfigManager:
         allow_empty_container=False,
         container_override: dict = None,
         check_files=True,
+        **kwargs,
     ) -> WorkflowManager:
 
         return WorkflowManager.from_janis(
@@ -203,6 +204,7 @@ class ConfigManager:
             allow_empty_container=allow_empty_container,
             container_override=container_override,
             check_files=check_files,
+            **kwargs,
         )
 
     def from_wid(self, wid, readonly=False):


### PR DESCRIPTION
We sort of suggest it would be possible in the talk, and I always thought it shouldn't be too technically hard to implement (as we convert the workflow to CWL / WDL anyway).

This PR tests packed CWL workflows with cwltool which WORKS!

There are a number of things that haven't been implemented yet:

- [ ] Type of workflow spec (CWL / WDL) - this changes which engines are compatible. The assistant was designed with this, and knows which specs each engine can support.
- [ ] Output collection (Janis has previously inferred from the outputs from the task description), we would need to change the way this works (and you'd lose the fancy janis output naming)
- [ ] Required a PACKED workflow. We could very theoretically pack it for the user.
- [ ] Inputs are expected to be _already_ formatted for the engine, include the `class: File` annotation for cwltool, or only json formatted for Cromwell.
- [ ] CWL support for cromwell is unclear, it would be good to clear up how to submit workflows again to Cromwell.
- \+ I'm sure many more things.

But this PR shows that Janis can be modular and you could jump out (or _IN_) at different stages.