### PR TITLE
enable init to pull cromwell without running anything.

### DIFF
--- a/janis_assistant/cli.py
+++ b/janis_assistant/cli.py
@@ -10,6 +10,7 @@ from janis_core.translationdeps.supportedtranslations import SupportedTranslatio
 
 from janis_assistant.__meta__ import DOCS_URL
 from janis_assistant.templates.templates import get_template_names
+from janis_assistant.engines import Cromwell
 from janis_assistant.engines.enginetypes import EngineType
 from janis_assistant.management.configuration import JanisConfiguration
 
@@ -606,6 +607,7 @@ def add_init_args(args):
         "--output",
         help="Location to overwrite to, defaults to: ~/.janis/janis.conf",
     )
+    args.add_argument("--ensure_cromwell", action="store_true", help="download cromwell if it is not already present")
 
     args.add_argument("template", choices=get_template_names())
 
@@ -621,6 +623,8 @@ def do_init(args):
         output_location=args.output,
         force=args.force,
     )
+    if args.ensure_cromwell:
+        cromwell_loc = Cromwell.resolve_jar(None)
 
 
 def do_version(_):

--- a/janis_assistant/cli.py
+++ b/janis_assistant/cli.py
@@ -607,7 +607,7 @@ def add_init_args(args):
         "--output",
         help="Location to overwrite to, defaults to: ~/.janis/janis.conf",
     )
-    args.add_argument("--ensure_cromwell", action="store_true", help="download cromwell if it is not already present")
+    args.add_argument("--ensure-cromwell", action="store_true", help="download cromwell if it is not already present")
 
     args.add_argument("template", choices=get_template_names())
 
@@ -625,6 +625,7 @@ def do_init(args):
     )
     if args.ensure_cromwell:
         cromwell_loc = Cromwell.resolve_jar(None)
+        Logger.info("Located Cromwell at: " + str(cromwell_loc))
 
 
 def do_version(_):

--- a/janis_assistant/engines/cromwell/main.py
+++ b/janis_assistant/engines/cromwell/main.py
@@ -414,7 +414,8 @@ class Cromwell(Engine):
         time = 6
         threading.Timer(time, self.poll_metadata).start()
 
-    def resolve_jar(self, cromwelljar):
+    @staticmethod
+    def resolve_jar(cromwelljar):
         from janis_assistant.management.configuration import JanisConfiguration
 
         man = JanisConfiguration.manager()
@@ -481,7 +482,7 @@ class Cromwell(Engine):
                     else:
                         print("\rCompleted download of cromwell", file=sys.stderr)
 
-            cromwellurl, cromwellfilename = self.get_latest_cromwell_url()
+            cromwellurl, cromwellfilename = Cromwell.get_latest_cromwell_url()
             Logger.info(
                 f"Couldn't find cromwell at any of the usual spots, downloading '{cromwellfilename}' now"
             )


### PR DESCRIPTION
Hi Janis,

I'm not sure if this is the best way to do this, but it allows us to use `janis init` to pull the cromwell jar.