### PR TITLE
Add skip digest lookup to cromwell

### DIFF
--- a/janis_assistant/engines/cromwell/cromwellconfiguration.py
+++ b/janis_assistant/engines/cromwell/cromwellconfiguration.py
@@ -733,10 +733,19 @@ JOBID=$({sbatch} \\
 
     class Docker(Serializable):
         class HashLookup(Serializable):
-            def __init__(self, enabled=True):
+            def __init__(
+                self, enabled=True, perform_registry_lookup_if_digest_is_provided=False
+            ):
                 self.enabled = enabled
+                self.perform_registry_lookup_if_digest_is_provided = (
+                    perform_registry_lookup_if_digest_is_provided
+                )
 
-        def __init__(self, hash_lookup=None):
+            key_map = {
+                "perform_registry_lookup_if_digest_is_provided": "perform-registry-lookup-if-digest-is-provided",
+            }
+
+        def __init__(self, hash_lookup=HashLookup()):
             if hash_lookup is not None and not isinstance(hash_lookup, self.HashLookup):
                 raise Exception(
                     "hash-lookup is not of type CromwellConfiguration.Docker.HashLookup"
@@ -745,7 +754,7 @@ JOBID=$({sbatch} \\
 
         @classmethod
         def default(cls):
-            return None
+            return cls()
             # return cls(hash_lookup=cls.HashLookup(enabled=False))
 
         key_map = {"hash_lookup": "hash-lookup"}


### PR DESCRIPTION
Related to change in https://github.com/broadinstitute/cromwell/pull/5545

Context:
- Cromwell performs a docker registry lookup of all dockers to get the digest and the dockerSize
- Cromwell requires the docker-digest to call-cache
- The dockerSize is only used on the Google backends (for automatically sizing the bootDisk)
- This registry lookup fails on Spartan because Cromwell fails to respect the system web_proxy, this breaks call-caching.

We almost always replace the floating tag with a digest, so the dockerSize is of no benefit to us right now, hence I've added a config option to disable the registry lookup if the docker digest is provided. This keeps call-caching working, and incidentally makes Janis workflows more resilient to transient failures of external container registries (like the [June 2020, quay.io outage](https://status.quay.io/incidents/kw2627bsdwd9)).

Adding the key `docker.perform-registry-lookup-if-digest-is-provided = false` won't change anything in Cromwell until this release goes out (Cromwell will ignore unused keys).

